### PR TITLE
simplify internal structure, add multiSet()

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ A table of contents for your REST service schema
 var SchemaTable = require("rest-schema-table/schema-table");
 
 var table = SchemaTable();
-table.set('/foo/:bar', {
+table.multiSet('/foo/:bar', {
   'GET': {
     'requestSchema': { ... },
     'responseSchema': { ... }
   }
 });
 
+//  {
+//      'GET /foo/:bar': {
+//          request: { ... },
+//          response: { ... }
+//      }
+//  }
 console.log('obj', table.toJSON());
 ```
 
@@ -32,14 +38,16 @@ console.log('obj', table.toJSON());
 
 SchemaTable is an in memory data structure that defines the interface
     of any network server.
-    
-It's designed to enforce REST semantics so it will restrict you
-    to defining your interface in terms of endpoints that are named
-    as URL patterns and having a set of methods that are named after
-    HTTP verbs.
+
+It currently encodes arbitrarly named operations which have
+    requests and responses.
+
+By convention it's recommended that you encode REST semantics
+    by naming your operations as
+    `"{HTTP_METHOD} {HTTP_URL_PATTERN}"`. i.e. your server has
+    a set of operations that are methods on resources.
     
 The requestSchema and responseSchema are arbitrary.
-
 
 ## Installation
 

--- a/docs.jsig
+++ b/docs.jsig
@@ -1,0 +1,21 @@
+type JSONSchema : Object
+type OperationName : String
+
+type SchemaTableStruct : Object<OperationName, {
+    request: JSONSchema,
+    response: JSONSchema
+}>
+
+type SchemaTable : {
+    set: (op: OperationName, {
+        requestSchema: JSONSchema,
+        responseSchema: JSONSchema
+    }) => void,
+    multiSet: (op: OperationName, Object<String, {
+        requestSchema: JSONSchema,
+        responseSchema: JSONSchema
+    }>) => void,
+    toJSON: () => SchemaTableStruct
+}
+
+rest-schema-table/schema-table : () => SchemaTable

--- a/schema-table.js
+++ b/schema-table.js
@@ -15,25 +15,41 @@ function SchemaTable() {
 
 var proto = SchemaTable.prototype;
 
-proto.set = function set(endpoint, methods) {
+proto.set = function set(endpoint, schemas) {
+    assert(typeof endpoint === 'string',
+        'endpoint must be a string');
+    assert(schemas && typeof schemas === 'object',
+        'schemas must be an object');
+
+    assert(schemas.requestSchema, 'requestSchema required');
+    assert(schemas.responseSchema, 'responseSchema required');
+
+    this.table[endpoint] = {
+        request: schemas.requestSchema,
+        response: schemas.responseSchema
+    };
+};
+
+proto.multiSet = function multiSet(endpoint, methods) {
+    var self = this;
     assert(typeof endpoint === 'string',
         'endpoint must be a string');
     assert(methods && typeof methods === 'object',
         'methods must be an object');
 
-    var schemas = {};
+    var endpoints = {};
     Object.keys(methods).forEach(function addSchema(key) {
         var h = methods[key];
 
-        assert(h.requestSchema, 'requestSchema required');
-        assert(h.responseSchema, 'responseSchema required');
-
-        schemas[key] = {
-            request: h.requestSchema,
-            response: h.responseSchema
+        endpoints[key + ' ' + endpoint] = {
+            requestSchema: h.requestSchema,
+            responseSchema: h.responseSchema
         };
     });
-    this.table[endpoint] = schemas;
+
+    Object.keys(endpoints).forEach(function setEndpoint(k) {
+        self.set(k, endpoints[k]);
+    });
 };
 
 proto.toJSON = function toJSON() {

--- a/test/schema-table.js
+++ b/test/schema-table.js
@@ -21,7 +21,7 @@ test('works with new', function t(assert) {
 test('can add endpoints', function t(assert) {
     var table = SchemaTable();
 
-    table.set('/foo', {
+    table.multiSet('/foo', {
         'GET': {
             requestSchema: {},
             responseSchema: {}
@@ -29,11 +29,9 @@ test('can add endpoints', function t(assert) {
     });
 
     assert.deepEqual(table.toJSON(), {
-        '/foo': {
-            'GET': {
-                request: {},
-                response: {}
-            }
+        'GET /foo': {
+            request: {},
+            response: {}
         }
     });
     assert.end();
@@ -43,7 +41,7 @@ test('add throws without args', function t(assert) {
     var table = SchemaTable();
 
     assert.throws(function throwIt() {
-        table.set();
+        table.multiSet();
     }, /endpoint must be a string/);
     assert.end();
 });
@@ -52,7 +50,7 @@ test('add throws with func', function t(assert) {
     var table = SchemaTable();
 
     assert.throws(function throwIt() {
-        table.set('/foo', function handler() {});
+        table.multiSet('/foo', function handler() {});
     }, /methods must be an object/);
     assert.end();
 });
@@ -60,7 +58,7 @@ test('add throws with func', function t(assert) {
 test('supports arbitrary methods', function t(assert) {
     var table = SchemaTable();
 
-    table.set('/foo', {
+    table.multiSet('/foo', {
         'GET': {
             requestSchema: {},
             responseSchema: {}
@@ -80,23 +78,21 @@ test('supports arbitrary methods', function t(assert) {
     });
 
     assert.deepEqual(table.toJSON(), {
-        '/foo': {
-            'GET': {
-                request: {},
-                response: {}
-            },
-            'POST': {
-                request: {},
-                response: {}
-            },
-            'X-WAT': {
-                request: {},
-                response: {}
-            },
-            'someKey': {
-                request: {},
-                response: {}
-            }
+        'GET /foo': {
+            request: {},
+            response: {}
+        },
+        'POST /foo': {
+            request: {},
+            response: {}
+        },
+        'X-WAT /foo': {
+            request: {},
+            response: {}
+        },
+        'someKey /foo': {
+            request: {},
+            response: {}
         }
     });
     assert.end();
@@ -104,13 +100,13 @@ test('supports arbitrary methods', function t(assert) {
 
 test('can add multiple schemas', function t(assert) {
     var table = SchemaTable();
-    table.set('/foo', {
+    table.multiSet('/foo', {
         'GET': {
             requestSchema: {},
             responseSchema: {}
         }
     });
-    table.set('/bar', {
+    table.multiSet('/bar', {
         'POST': {
             requestSchema: {},
             responseSchema: {}
@@ -118,12 +114,8 @@ test('can add multiple schemas', function t(assert) {
     });
 
     assert.deepEqual(table.toJSON(), {
-        '/foo': {
-            'GET': { request: {}, response: {} }
-        },
-        '/bar': {
-            'POST': { request: {}, response: {} }
-        }
+        'GET /foo': { request: {}, response: {} },
+        'POST /bar': { request: {}, response: {} }
     });
     assert.end();
 });
@@ -131,7 +123,7 @@ test('can add multiple schemas', function t(assert) {
 test('can get data out', function t(assert) {
     var table = SchemaTable();
 
-    table.set('/foo', {
+    table.multiSet('/foo', {
         'GET': {
             requestSchema: {},
             responseSchema: {}
@@ -139,19 +131,18 @@ test('can get data out', function t(assert) {
     });
 
     assert.deepEqual(table.toJSON(), {
-        '/foo': {
-            'GET': {
-                request: {},
-                response: {}
-            }
+        'GET /foo': {
+            request: {},
+            response: {}
         }
     });
     assert.end();
 });
+
 test('data that comes out is a copy', function t(assert) {
     var table = SchemaTable();
 
-    table.set('/foo', {
+    table.multiSet('/foo', {
         'GET': {
             requestSchema: {},
             responseSchema: {}
@@ -172,14 +163,108 @@ test('throws assertions for missing schemas', function t(assert) {
     var table = SchemaTable();
 
     assert.throws(function throwIt() {
-        table.set('/foo', {
+        table.multiSet('/foo', {
             'GET': {}
         });
     }, /requestSchema required/);
     assert.throws(function throwIt() {
-        table.set('/bar', {
+        table.multiSet('/bar', {
             'POST': { requestSchema: {} }
         });
     }, /responseSchema required/);
+    assert.end();
+});
+
+test('set can add operations', function t(assert) {
+    var table = SchemaTable();
+
+    table.set('foo', {
+        requestSchema: {},
+        responseSchema: {}
+    });
+
+    assert.deepEqual(table.toJSON(), {
+        'foo': { request: {}, response: {} }
+    });
+    assert.end();
+});
+
+test('set can add operations with method', function t(assert) {
+    var table = SchemaTable();
+
+    table.set('GET foo', {
+        requestSchema: {},
+        responseSchema: {}
+    });
+
+    assert.deepEqual(table.toJSON(), {
+        'GET foo': { request: {}, response: {} }
+    });
+    assert.end();
+});
+
+test('set throws without args', function t(assert) {
+    var table = SchemaTable();
+
+    assert.throws(function throwIt() {
+        table.set();
+    }, /endpoint must be a string/);
+
+    assert.end();
+});
+
+test('set throws with non-object', function t(assert) {
+    var table = SchemaTable();
+
+    assert.throws(function throwIt() {
+        table.set('foo', function handler() {});
+    }, /schemas must be an object/);
+
+    assert.end();
+});
+
+test('set throws without requestSchema', function t(assert) {
+    var table = SchemaTable();
+
+    assert.throws(function throwIt() {
+        table.set('foo', {});
+    }, /requestSchema required/);
+
+    assert.end();
+});
+
+test('set throws without responseSchema', function t(assert) {
+    var table = SchemaTable();
+
+    assert.throws(function throwIt() {
+        table.set('foo', { requestSchema: {} });
+    }, /responseSchema required/);
+
+    assert.end();
+});
+
+test('can set multiple ops', function t(assert) {
+    var table = SchemaTable();
+
+    table.set('GET foo', {
+        requestSchema: {},
+        responseSchema: {}
+    });
+    table.set('POST bar', {
+        requestSchema: {},
+        responseSchema: {}
+    });
+
+    assert.deepEqual(table.toJSON(), {
+        'GET foo': {
+            request: {},
+            response: {}
+        },
+        'POST bar': {
+            request: {},
+            response: {}
+        }
+    });
+
     assert.end();
 });


### PR DESCRIPTION
This changes the schema-table interface. This is an interface
    that multiple tools will operate with including

 - ringpop-http-shard
 - schema-version ( to be implemented )
 - schema-markdown ( to be implemented )
 - fake-schema-server ( to be implemented )

To have better compatibility with other protocols like thrift
    and tchannel, I've encoded the HTTP method and HTTP url
    in the operation name.

cc @Matt-Esch @kriskowal @sh1mmer