### PR TITLE
implement endpoint name validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,67 @@
-throw new Error('not implemented');
+'use strict';
+
+var inherits = require('inherits');
+var methods = require('methods');
+var assert = require('assert');
+
+var SchemaTable = require('./schema-table.js');
+
+var plainWordRegex = /^\w+$/;
+var METHODS_HASH = methods.reduce(function buildHash(acc, k) {
+    acc[k.toUpperCase()] = true;
+    return acc;
+}, {});
+
+module.exports = RestSchemaTable;
+
+function RestSchemaTable() {
+    if (!(this instanceof RestSchemaTable)) {
+        return new RestSchemaTable();
+    }
+
+    SchemaTable.call(this);
+}
+
+inherits(RestSchemaTable, SchemaTable);
+
+var proto = RestSchemaTable.prototype;
+
+proto.set = function set(endpoint, schemas) {
+    assert(typeof endpoint === 'string',
+        'expected string endpoint');
+    var parts = endpoint.split(' ');
+    assert(parts.length === 2, 'expected only two parts');
+    var httpMethod = parts[0];
+    var uriPattern = parts[1];
+
+    assert(METHODS_HASH[httpMethod],
+        'expected valid HTTP method');
+
+    assertPattern(uriPattern);
+
+    SchemaTable.prototype.set.call(this, endpoint, schemas);
+};
+
+function assertPattern(uriPattern) {
+    var parts = uriPattern.split('/');
+
+    assert(parts[0] === '', 'expected leading slash');
+
+    parts = parts.slice(1);
+
+    for (var i = 0; i < parts.length; i++) {
+        var part = parts[i];
+        var hasSplat = part.indexOf('*') >= 0;
+        var isParam = part.indexOf(':') === 0;
+
+        if (hasSplat &&
+            (part.length > 1 || i !== parts.length - 1)
+        ) {
+            assert(false, 'expected * to be trailing');
+        }
+
+        if (isParam && !part.slice(1).match(plainWordRegex)) {
+            assert(false, 'expected params to be plain word');
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",
   "repository": "git://github.com/Raynos/rest-schema-table.git",
-  "main": "index",
+  "main": "index.js",
   "homepage": "https://github.com/Raynos/rest-schema-table",
   "bugs": {
     "url": "https://github.com/Raynos/rest-schema-table/issues",
@@ -18,15 +18,16 @@
   ],
   "dependencies": {
     "assert": "^1.3.0",
+    "inherits": "^2.0.1",
+    "methods": "^1.1.1",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.10.0",
     "istanbul": "^0.2.7",
     "itape": "^1.3.0",
-    "jshint": "^2.5.0",
+    "lint-trap": "^1.0.0",
     "pre-commit": "0.0.5",
-    "run-browser": "^1.3.0",
     "tap-spec": "^0.1.8",
     "tape": "^2.12.3"
   },
@@ -37,22 +38,19 @@
     }
   ],
   "scripts": {
-    "test": "npm run jshint -s && NODE_ENV=test node test/index.js | tap-spec",
-    "unit-test": "NODE_ENV=test node test/index.js | tap-spec",
-    "jshint-pre-commit": "jshint --verbose $(git diff --cached --name-only | grep '\\.js$')",
-    "jshint": "jshint --verbose .",
-    "cover": "istanbul cover --report none --print detail test/index.js",
-    "view-cover": "istanbul report html && open ./coverage/index.html",
-    "travis": "npm run cover -s && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)",
-    "phantom": "run-browser test/index.js -b",
-    "browser": "run-browser test/index.js"
+    "test": "npm run jshint -s && npm run cover -s",
+    "jshint": "lint-trap .",
+    "cover": "istanbul cover --report html --print detail -- test/index.js && npm run check-cover -s",
+    "check-cover": "istanbul check-coverage --branches=100 --lines=100 --functions=100",
+    "view-cover": "opn ./coverage/index.html",
+    "travis": "npm run cover -s && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)"
   },
   "engine": {
     "node": ">= 0.8.x"
   },
   "pre-commit": [
-    "jshint-pre-commit",
-    "unit-test"
+    "test"
   ],
+  "pre-commit.version": true,
   "ngen-version": "4.0.3"
 }

--- a/schema-table.js
+++ b/schema-table.js
@@ -31,25 +31,22 @@ proto.set = function set(endpoint, schemas) {
 };
 
 proto.multiSet = function multiSet(endpoint, methods) {
-    var self = this;
     assert(typeof endpoint === 'string',
         'endpoint must be a string');
     assert(methods && typeof methods === 'object',
         'methods must be an object');
 
-    var endpoints = {};
-    Object.keys(methods).forEach(function addSchema(key) {
+    var methodNames = Object.keys(methods);
+
+    for (var i = 0; i < methodNames.length; i++) {
+        var key = methodNames[i];
         var h = methods[key];
 
-        endpoints[key + ' ' + endpoint] = {
+        this.set(key + ' ' + endpoint, {
             requestSchema: h.requestSchema,
             responseSchema: h.responseSchema
-        };
-    });
-
-    Object.keys(endpoints).forEach(function setEndpoint(k) {
-        self.set(k, endpoints[k]);
-    });
+        });
+    }
 };
 
 proto.toJSON = function toJSON() {

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
 'use strict';
 
 require('./schema-table.js');
+require('./rest-schema-table.js');

--- a/test/rest-schema-table.js
+++ b/test/rest-schema-table.js
@@ -1,0 +1,278 @@
+'use strict';
+
+var test = require('tape');
+
+var RestSchemaTable = require('../index.js');
+
+test('can alloc with new', function t(assert) {
+    var table = new RestSchemaTable();
+
+    table.set('GET /foo', {
+        requestSchema: {}, responseSchema: {}
+    });
+
+    assert.deepEqual(table.toJSON(), {
+        'GET /foo': {
+            request: {}, response: {}
+        }
+    });
+
+    assert.end();
+});
+
+test('can alloc without new', function t(assert) {
+    var table = RestSchemaTable();
+
+    table.set('GET /foo', {
+        requestSchema: {}, responseSchema: {}
+    });
+
+    assert.deepEqual(table.toJSON(), {
+        'GET /foo': {
+            request: {}, response: {}
+        }
+    });
+
+    assert.end();
+});
+
+test('throws with invalid method', function t(assert) {
+    var table = RestSchemaTable();
+
+    assert.throws(function throwIt() {
+        table.set('get /foo');
+    }, /expected valid HTTP method/);
+
+    assert.throws(function throwIt() {
+        table.set('X-POST /foo');
+    }, /expected valid HTTP method/);
+
+    assert.doesNotThrow(function noThrow() {
+        table.set('GET /foo', {
+            requestSchema: {}, responseSchema: {}
+        });
+    });
+
+    assert.doesNotThrow(function noThrow() {
+        table.set('POST /foo', {
+            requestSchema: {}, responseSchema: {}
+        });
+    });
+
+    assert.end();
+});
+
+test('throws with weird parts', function t(assert) {
+    var table = RestSchemaTable();
+
+    assert.throws(function throwIt() {
+        table.set('single-word');
+    }, /expected only two parts/);
+
+    assert.throws(function throwIt() {
+        table.set('');
+    }, /expected only two parts/);
+
+    assert.throws(function throwIt() {
+        table.set();
+    }, /expected string endpoint/);
+
+    assert.throws(function throwIt() {
+        table.set('foo bar baz');
+    }, /expected only two parts/);
+
+    assert.end();
+});
+
+test('throws with invalid url pattern', function t(assert) {
+    var table = RestSchemaTable();
+
+    assert.throws(function throwIt() {
+        table.set('GET /foo/*/baz');
+    }, /expected \* to be trailing/);
+
+    assert.doesNotThrow(function noThrow() {
+        table.set('GET /foo/baz/*', {
+            requestSchema: {}, responseSchema: {}
+        });
+    }, /lul/);
+
+    assert.throws(function throwIt() {
+        table.set('GET /foo/:invalid-id');
+    }, /expected params to be plain word/);
+
+    assert.doesNotThrow(function noThrow() {
+        table.set('GET /foo/:valid_id', {
+            requestSchema: {}, responseSchema: {}
+        });
+    }, /lul/);
+
+    assert.throws(function throwIt() {
+        table.set('GET no-leading/slash');
+    }, /expected leading slash/);
+
+    assert.doesNotThrow(function noThrow() {
+        table.set('GET /leading/slash', {
+            requestSchema: {}, responseSchema: {}
+        });
+    }, /lul/);
+
+    assert.end();
+});
+
+test('can add endpoints', function t(assert) {
+    var table = RestSchemaTable();
+
+    table.multiSet('/foo', {
+        'GET': {
+            requestSchema: {},
+            responseSchema: {}
+        }
+    });
+
+    assert.deepEqual(table.toJSON(), {
+        'GET /foo': {
+            request: {},
+            response: {}
+        }
+    });
+    assert.end();
+});
+
+test('add throws without args', function t(assert) {
+    var table = RestSchemaTable();
+
+    assert.throws(function throwIt() {
+        table.multiSet();
+    }, /endpoint must be a string/);
+    assert.end();
+});
+
+test('add throws with func', function t(assert) {
+    var table = RestSchemaTable();
+
+    assert.throws(function throwIt() {
+        table.multiSet('/foo', function handler() {});
+    }, /methods must be an object/);
+    assert.end();
+});
+
+test('supports valid http methods', function t(assert) {
+    var table = RestSchemaTable();
+
+    table.multiSet('/foo', {
+        'GET': {
+            requestSchema: {},
+            responseSchema: {}
+        },
+        'POST': {
+            requestSchema: {},
+            responseSchema: {}
+        },
+        'PUT': {
+            requestSchema: {},
+            responseSchema: {}
+        },
+        'PATCH': {
+            requestSchema: {},
+            responseSchema: {}
+        }
+    });
+
+    assert.deepEqual(table.toJSON(), {
+        'GET /foo': {
+            request: {},
+            response: {}
+        },
+        'POST /foo': {
+            request: {},
+            response: {}
+        },
+        'PUT /foo': {
+            request: {},
+            response: {}
+        },
+        'PATCH /foo': {
+            request: {},
+            response: {}
+        }
+    });
+    assert.end();
+});
+
+test('can add multiple schemas', function t(assert) {
+    var table = RestSchemaTable();
+    table.multiSet('/foo', {
+        'GET': {
+            requestSchema: {},
+            responseSchema: {}
+        }
+    });
+    table.multiSet('/bar', {
+        'POST': {
+            requestSchema: {},
+            responseSchema: {}
+        }
+    });
+
+    assert.deepEqual(table.toJSON(), {
+        'GET /foo': { request: {}, response: {} },
+        'POST /bar': { request: {}, response: {} }
+    });
+    assert.end();
+});
+
+test('can get data out', function t(assert) {
+    var table = RestSchemaTable();
+
+    table.multiSet('/foo', {
+        'GET': {
+            requestSchema: {},
+            responseSchema: {}
+        }
+    });
+
+    assert.deepEqual(table.toJSON(), {
+        'GET /foo': {
+            request: {},
+            response: {}
+        }
+    });
+    assert.end();
+});
+
+test('data that comes out is a copy', function t(assert) {
+    var table = RestSchemaTable();
+
+    table.multiSet('/foo', {
+        'GET': {
+            requestSchema: {},
+            responseSchema: {}
+        }
+    });
+
+    var one = table.toJSON();
+    var two = table.toJSON();
+
+    one.foo = 'bar';
+    assert.equal(one.foo, 'bar');
+    assert.equal(two.foo, undefined);
+
+    assert.end();
+});
+
+test('throws assertions for missing schemas', function t(assert) {
+    var table = RestSchemaTable();
+
+    assert.throws(function throwIt() {
+        table.multiSet('/foo', {
+            'GET': {}
+        });
+    }, /requestSchema required/);
+    assert.throws(function throwIt() {
+        table.multiSet('/bar', {
+            'POST': { requestSchema: {} }
+        });
+    }, /responseSchema required/);
+    assert.end();
+});


### PR DESCRIPTION
This is a first pass at the REST assertions.

All we are doing for now is asserting the operation name is a valid
    'HTTP_METHOD HTTP_URL_PATTERN' string.

This will ensure that anyone who constructs a schema table upholds
    our expected invariants

cc @kriskowal @sh1mmer @Matt-Esch
